### PR TITLE
Unmarshal Method Nil Pointers

### DIFF
--- a/gentests/bindata/bindata.go
+++ b/gentests/bindata/bindata.go
@@ -35,9 +35,13 @@ func (t *Bindata) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		B64Data *xsdBase64Binary `xml:"tns b64Data"`
 	}
 	overlay.T = (*T)(t)
-	overlay.HexData = (*xsdHexBinary)(&overlay.T.HexData)
-	overlay.B64Data = (*xsdBase64Binary)(&overlay.T.B64Data)
-	return d.DecodeElement(&overlay, &start)
+	err := d.DecodeElement(&overlay, &start)
+	if err != nil {
+		return err
+	}
+	overlay.T.HexData = ([]byte)(*overlay.HexData)
+	overlay.T.B64Data = ([]byte)(*overlay.B64Data)
+	return nil
 }
 
 type xsdBase64Binary []byte

--- a/gentests/books/books.go
+++ b/gentests/books/books.go
@@ -14,7 +14,7 @@ type BookForm struct {
 	Genre              string     `xml:"urn:books genre"`
 	Price              float32    `xml:"urn:books price"`
 	Pubdate            time.Time  `xml:"urn:books pub_date"`
-	Firstrevisiondate  time.Time  `xml:"urn:books first_revision_date"`
+	Firstrevisiondate  *time.Time `xml:"urn:books first_revision_date,omitempty"`
 	Secondrevisiondate *time.Time `xml:"urn:books second_revision_date,omitempty"`
 	Review             string     `xml:"urn:books review"`
 	Name               string     `xml:"urn:books name,attr,omitempty"`
@@ -25,12 +25,12 @@ func (t *BookForm) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	var layout struct {
 		*T
 		Pubdate            *xsdDate `xml:"urn:books pub_date"`
-		Firstrevisiondate  *xsdDate `xml:"urn:books first_revision_date"`
+		Firstrevisiondate  *xsdDate `xml:"urn:books first_revision_date,omitempty"`
 		Secondrevisiondate *xsdDate `xml:"urn:books second_revision_date,omitempty"`
 	}
 	layout.T = (*T)(t)
 	layout.Pubdate = (*xsdDate)(&layout.T.Pubdate)
-	layout.Firstrevisiondate = (*xsdDate)(&layout.T.Firstrevisiondate)
+	layout.Firstrevisiondate = (*xsdDate)(layout.T.Firstrevisiondate)
 	layout.Secondrevisiondate = (*xsdDate)(layout.T.Secondrevisiondate)
 	return e.EncodeElement(layout, start)
 }
@@ -39,7 +39,7 @@ func (t *BookForm) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var overlay struct {
 		*T
 		Pubdate            *xsdDate `xml:"urn:books pub_date"`
-		Firstrevisiondate  *xsdDate `xml:"urn:books first_revision_date"`
+		Firstrevisiondate  *xsdDate `xml:"urn:books first_revision_date,omitempty"`
 		Secondrevisiondate *xsdDate `xml:"urn:books second_revision_date,omitempty"`
 	}
 	overlay.T = (*T)(t)
@@ -48,7 +48,7 @@ func (t *BookForm) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 	overlay.T.Pubdate = (time.Time)(*overlay.Pubdate)
-	overlay.T.Firstrevisiondate = (time.Time)(*overlay.Firstrevisiondate)
+	overlay.T.Firstrevisiondate = (*time.Time)(overlay.Firstrevisiondate)
 	overlay.T.Secondrevisiondate = (*time.Time)(overlay.Secondrevisiondate)
 	return nil
 }

--- a/gentests/books/books.xml
+++ b/gentests/books/books.xml
@@ -6,6 +6,8 @@
       <genre>Fiction</genre>
       <price>44.95</price>
       <pub_date>2000-10-01</pub_date>
+      <first_revision_date>2001-01-01</first_revision_date>
+      <second_revision_date>2002-01-01</second_revision_date>
       <review>An amazing story of nothing.</review>
    </book>
 
@@ -16,5 +18,6 @@
       <price>24.95</price>
       <review>Least poetic poems.</review>
       <pub_date>2003-12-01</pub_date>
+      <first_revision_date>2004-01-01</first_revision_date>
    </book>
 </books>

--- a/gentests/books/books.xsd
+++ b/gentests/books/books.xsd
@@ -20,7 +20,7 @@
       <xsd:element name="genre" type="xsd:string"/>
       <xsd:element name="price" type="xsd:float"/>
       <xsd:element name="pub_date" type="xsd:date"/>
-      <xsd:element name="first_revision_date" type="xsd:date" use="optional"/>
+      <xsd:element name="first_revision_date" type="xsd:date" nillable="true"/>
       <xsd:element name="second_revision_date" type="xsd:date" nillable="true" />
       <xsd:element name="review" type="xsd:string"/>
     </xsd:sequence>

--- a/gentests/books/books.xsd
+++ b/gentests/books/books.xsd
@@ -6,21 +6,23 @@
 
   <xsd:complexType name="BooksForm">
     <xsd:sequence>
-      <xsd:element name="book" 
-                  type="bks:BookForm" 
-                  minOccurs="0" 
-                  maxOccurs="unbounded"/>
-      </xsd:sequence>
+      <xsd:element name="book"
+                   type="bks:BookForm"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="BookForm">
     <xsd:sequence>
-      <xsd:element name="author"   type="xsd:string"/>
-      <xsd:element name="title"    type="xsd:string"/>
-      <xsd:element name="genre"    type="xsd:string"/>
-      <xsd:element name="price"    type="xsd:float" />
-      <xsd:element name="pub_date" type="xsd:date" />
-      <xsd:element name="review"   type="xsd:string"/>
+      <xsd:element name="author" type="xsd:string"/>
+      <xsd:element name="title" type="xsd:string"/>
+      <xsd:element name="genre" type="xsd:string"/>
+      <xsd:element name="price" type="xsd:float"/>
+      <xsd:element name="pub_date" type="xsd:date"/>
+      <xsd:element name="first_revision_date" type="xsd:date" use="optional"/>
+      <xsd:element name="second_revision_date" type="xsd:date" nillable="true" />
+      <xsd:element name="review" type="xsd:string"/>
     </xsd:sequence>
     <xsd:attribute name="name" form="qualified" type="xsd:string"/>
   </xsd:complexType>

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -313,8 +313,12 @@ func ExampleUseFieldNames() {
 	// 		Published *xsdDate `xml:"http://www.example.com/ published"`
 	// 	}
 	// 	overlay.T = (*T)(t)
-	// 	overlay.Published = (*xsdDate)(&overlay.T.Published)
-	// 	return d.DecodeElement(&overlay, &start)
+	// 	err := d.DecodeElement(&overlay, &start)
+	// 	if err != nil {
+	//		return err
+	//	}
+	// 	overlay.T.Published = (time.Time)(*overlay.Published)
+	// 	return nil
 	// }
 	//
 	// type Library struct {


### PR DESCRIPTION
- it seems that the original repo is not seeing a lot of activity, and I see that your PR is a bit old at this point as well, but I actually had to implement similar changes to this on a fork my company uses so I figured I'd go ahead and try to submit them to the original as well, but you had already started down the path of implementing pointers for optional types, so I thought your branch was the right place to submit this
- after implementing the change to implement pointers for optional types, it seems that the `UnmarshalXML` method that gets generated actually results in nil values for pointer type like `*time.Time`. I updated the unmarshaling methods that get generated to assign values to fields more explicitly so that we don't end up with nil pointers.
- there were tests that were already failing and they're still failing as after my update because my update doesn't aim to address them, however if you review output for the generated tests that fail in `books` you can see that my change is outputting the values as you'd expect, however the unexpected output causing the failure actually already exists regardless of my changes, so if the tests were passing before I made my changes (which they aren't once you regenerate them) then they would be passing after I made my changes, if that makes any sense lol